### PR TITLE
2 tiger data blocked with 403

### DIFF
--- a/uwpostgis-foundry/src/alpinedb/state_download_layer.sh
+++ b/uwpostgis-foundry/src/alpinedb/state_download_layer.sh
@@ -36,7 +36,7 @@ get_fips_from_abbr () {
 get_fips_files () {
     local url=$1
     local fips=$2
-    local files=($(wget --no-verbose -O - $url \
+    local files=($(wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" --no-verbose -O - $url \
         | perl -nle 'print if m{(?=\"tl)(.*?)(?<=>)}g' \
         | perl -nle 'print m{(?=\"tl)(.*?)(?<=>)}g' | sed -e 's/[\"]//g'  | sed -e 's/[>]//g' ))
     local matched=($(echo "${files[*]}" | tr ' ' '\n' | grep "tl_${YEAR}_${fips}"  ))
@@ -45,7 +45,7 @@ get_fips_files () {
 
 load_national_data () {
     cd $GISDATA
-    wget ${BASEURL}/STATE/tl_${YEAR}_us_state.zip --mirror --reject=html --no-verbose
+    wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" ${BASEURL}/STATE/tl_${YEAR}_us_state.zip --mirror --reject=html --no-verbose
     cd ${BASEPATH}/STATE
 
     $UNZIPTOOL tl_${YEAR}_us_state.zip
@@ -58,7 +58,7 @@ load_national_data () {
 
 
     cd $GISDATA
-    wget ${BASEURL}/COUNTY/tl_${YEAR}_us_county.zip --mirror --reject=html --no-verbose
+    wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" ${BASEURL}/COUNTY/tl_${YEAR}_us_county.zip --mirror --reject=html --no-verbose
     cd $GISDATA/${BASEPATH}/COUNTY
 
     for z in tl_*county.zip ; 
@@ -82,7 +82,7 @@ load_state_data () {
 
     for i in "${files[@]}" 
     do 
-        wget $BASEURL/ADDR/$i --no-verbose --mirror  
+        wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" $BASEURL/ADDR/$i --no-verbose --mirror  
     done
                                                                                                                                                                                                                                                                                                                                                                                                                                                       
     cd $GISDATA/$BASEPATH/ADDR                                                                                                                                                                                                                                                                                                                                                                                                                      
@@ -97,7 +97,7 @@ load_state_data () {
     # Place
     #############                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
     cd $GISDATA                                                                                                                                                                                                                                                                                                                                                                                                                                                       
-    wget $BASEURL/PLACE/tl_${YEAR}_${FIPS}_place.zip --mirror --reject=html --no-verbose                                                                                                                                                                                                                                                                                                                                                                    
+    wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" $BASEURL/PLACE/tl_${YEAR}_${FIPS}_place.zip --mirror --reject=html --no-verbose                                                                                                                                                                                                                                                                                                                                                                    
     cd $GISDATA/$BASEPATH/PLACE                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                   
     for z in tl_${YEAR}_${FIPS}*_place.zip ; 
@@ -110,7 +110,7 @@ load_state_data () {
     # Cousub
     #############   
     cd $GISDATA                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
-    wget $BASEURL/COUSUB/tl_${YEAR}_${FIPS}_cousub.zip --mirror --reject=html --no-verbose
+    wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" $BASEURL/COUSUB/tl_${YEAR}_${FIPS}_cousub.zip --mirror --reject=html --no-verbose
     cd $GISDATA/$BASEPATH/COUSUB                                                                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                
     for z in tl_${YEAR}_${FIPS}*_cousub.zip ; 
@@ -123,7 +123,7 @@ load_state_data () {
     # Tract
     #############   
     cd $GISDATA                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
-    wget $BASEURL/TRACT/tl_${YEAR}_${FIPS}_tract.zip --mirror --reject=html --no-verbose
+    wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" $BASEURL/TRACT/tl_${YEAR}_${FIPS}_tract.zip --mirror --reject=html --no-verbose
     cd $GISDATA/$BASEPATH/TRACT                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                 
     for z in tl_${YEAR}_${FIPS}*_tract.zip ; 
@@ -140,7 +140,7 @@ load_state_data () {
 
     for i in "${files[@]}"
     do
-        wget $BASEURL/FACES/$i --no-verbose --mirror 
+        wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" $BASEURL/FACES/$i --no-verbose --mirror 
     done
 
     cd $GISDATA/$BASEPATH/FACES/                                                                                                                                                                                                                                                                                                                                                                                                                      
@@ -159,7 +159,7 @@ load_state_data () {
 
     for i in "${files[@]}"
     do
-        wget $BASEURL/FEATNAMES/$i --no-verbose --mirror 
+        wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" $BASEURL/FEATNAMES/$i --no-verbose --mirror 
     done
 
     cd $GISDATA/$BASEPATH/FEATNAMES/
@@ -181,7 +181,7 @@ load_state_data () {
 
     for i in "${files[@]}"
     do
-        wget $BASEURL/EDGES/$i --no-verbose --mirror 
+        wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" $BASEURL/EDGES/$i --no-verbose --mirror 
     done
 
     cd $GISDATA/$BASEPATH/EDGES                                                                                                                                                                                                                                                                                                                                                                                                                       

--- a/uwpostgis-foundry/src/alpinedb/state_download_layer.sh
+++ b/uwpostgis-foundry/src/alpinedb/state_download_layer.sh
@@ -4,8 +4,9 @@ GISDATA="/gisdata"
 TMPDIR="${GISDATA}/temp/"
 UNZIPTOOL=unzip
 YEAR=2020
-BASEPATH="/geo/tiger/TIGER${YEAR}"
-BASEURL="http://www2.census.gov${BASEPATH}"
+# as used by wget path
+BASEPATH="www2.census.gov/geo/tiger/TIGER${YEAR}"
+BASEURL="http://${BASEPATH}"
 #BASEURL="http://clad-github-builder.rit.uw.edu${BASEPATH}"
 
 mkdir -p ${TMPDIR}

--- a/uwpostgis-foundry/src/alpinedb/state_download_layer.sh
+++ b/uwpostgis-foundry/src/alpinedb/state_download_layer.sh
@@ -4,8 +4,9 @@ GISDATA="/gisdata"
 TMPDIR="${GISDATA}/temp/"
 UNZIPTOOL=unzip
 YEAR=2020
-BASEPATH="www2.census.gov/geo/tiger/TIGER${YEAR}"
-BASEURL="https://${BASEPATH}"
+BASEPATH="/geo/tiger/TIGER${YEAR}"
+BASEURL="http://www2.census.gov${BASEPATH}"
+#BASEURL="http://clad-github-builder.rit.uw.edu${BASEPATH}"
 
 mkdir -p ${TMPDIR}
 
@@ -36,7 +37,7 @@ get_fips_from_abbr () {
 get_fips_files () {
     local url=$1
     local fips=$2
-    local files=($(wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" --no-verbose -O - $url \
+    local files=($(wget --no-verbose -O - $url \
         | perl -nle 'print if m{(?=\"tl)(.*?)(?<=>)}g' \
         | perl -nle 'print m{(?=\"tl)(.*?)(?<=>)}g' | sed -e 's/[\"]//g'  | sed -e 's/[>]//g' ))
     local matched=($(echo "${files[*]}" | tr ' ' '\n' | grep "tl_${YEAR}_${fips}"  ))
@@ -45,7 +46,7 @@ get_fips_files () {
 
 load_national_data () {
     cd $GISDATA
-    wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" ${BASEURL}/STATE/tl_${YEAR}_us_state.zip --mirror --reject=html --no-verbose
+    wget ${BASEURL}/STATE/tl_${YEAR}_us_state.zip --mirror --reject=html --no-verbose
     cd ${BASEPATH}/STATE
 
     $UNZIPTOOL tl_${YEAR}_us_state.zip
@@ -58,7 +59,7 @@ load_national_data () {
 
 
     cd $GISDATA
-    wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" ${BASEURL}/COUNTY/tl_${YEAR}_us_county.zip --mirror --reject=html --no-verbose
+    wget ${BASEURL}/COUNTY/tl_${YEAR}_us_county.zip --mirror --reject=html --no-verbose
     cd $GISDATA/${BASEPATH}/COUNTY
 
     for z in tl_*county.zip ; 
@@ -82,7 +83,7 @@ load_state_data () {
 
     for i in "${files[@]}" 
     do 
-        wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" $BASEURL/ADDR/$i --no-verbose --mirror  
+        wget $BASEURL/ADDR/$i --no-verbose --mirror  
     done
                                                                                                                                                                                                                                                                                                                                                                                                                                                       
     cd $GISDATA/$BASEPATH/ADDR                                                                                                                                                                                                                                                                                                                                                                                                                      
@@ -97,7 +98,7 @@ load_state_data () {
     # Place
     #############                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
     cd $GISDATA                                                                                                                                                                                                                                                                                                                                                                                                                                                       
-    wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" $BASEURL/PLACE/tl_${YEAR}_${FIPS}_place.zip --mirror --reject=html --no-verbose                                                                                                                                                                                                                                                                                                                                                                    
+    wget $BASEURL/PLACE/tl_${YEAR}_${FIPS}_place.zip --mirror --reject=html --no-verbose                                                                                                                                                                                                                                                                                                                                                                    
     cd $GISDATA/$BASEPATH/PLACE                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                   
     for z in tl_${YEAR}_${FIPS}*_place.zip ; 
@@ -110,7 +111,7 @@ load_state_data () {
     # Cousub
     #############   
     cd $GISDATA                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
-    wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" $BASEURL/COUSUB/tl_${YEAR}_${FIPS}_cousub.zip --mirror --reject=html --no-verbose
+    wget $BASEURL/COUSUB/tl_${YEAR}_${FIPS}_cousub.zip --mirror --reject=html --no-verbose
     cd $GISDATA/$BASEPATH/COUSUB                                                                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                
     for z in tl_${YEAR}_${FIPS}*_cousub.zip ; 
@@ -123,7 +124,7 @@ load_state_data () {
     # Tract
     #############   
     cd $GISDATA                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
-    wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" $BASEURL/TRACT/tl_${YEAR}_${FIPS}_tract.zip --mirror --reject=html --no-verbose
+    wget $BASEURL/TRACT/tl_${YEAR}_${FIPS}_tract.zip --mirror --reject=html --no-verbose
     cd $GISDATA/$BASEPATH/TRACT                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                 
     for z in tl_${YEAR}_${FIPS}*_tract.zip ; 
@@ -140,7 +141,7 @@ load_state_data () {
 
     for i in "${files[@]}"
     do
-        wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" $BASEURL/FACES/$i --no-verbose --mirror 
+        wget $BASEURL/FACES/$i --no-verbose --mirror 
     done
 
     cd $GISDATA/$BASEPATH/FACES/                                                                                                                                                                                                                                                                                                                                                                                                                      
@@ -159,7 +160,7 @@ load_state_data () {
 
     for i in "${files[@]}"
     do
-        wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" $BASEURL/FEATNAMES/$i --no-verbose --mirror 
+        wget $BASEURL/FEATNAMES/$i --no-verbose --mirror 
     done
 
     cd $GISDATA/$BASEPATH/FEATNAMES/
@@ -181,7 +182,7 @@ load_state_data () {
 
     for i in "${files[@]}"
     do
-        wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" $BASEURL/EDGES/$i --no-verbose --mirror 
+        wget $BASEURL/EDGES/$i --no-verbose --mirror 
     done
 
     cd $GISDATA/$BASEPATH/EDGES                                                                                                                                                                                                                                                                                                                                                                                                                       


### PR DESCRIPTION
change basepath to just the path
switch to http by default (allows redirect to use local cache on builder)